### PR TITLE
에러 수정 및 리팩토링 사항

### DIFF
--- a/nugu/User.js
+++ b/nugu/User.js
@@ -147,20 +147,18 @@ const db = require('../db/db');
     getReceipes() {
 
         let temp = [] ;
-        if(this.receipes && this.receipes.length){
-            for(let [key,value] of this.receipes) {
+        
+        if(this.receipes.length === 0) return null;
+        
+        for(let [key,value] of this.receipes) {
                 if(temp.length < 3) {
                     temp.push(value);
                     this.removeReceipe(key);
                 }
-            }
-            return temp;
         }
-        else    
-            return null;
-        
-
+        return temp;
     }
+                
 
     removeReceipe(key) {
     	this.receipes.delete(key);

--- a/nugu/nuguService.js
+++ b/nugu/nuguService.js
@@ -17,44 +17,51 @@ module.exports.nuguService = {
 
         const user = new User();
         
-	user.setId = id;
+		user.setId = id;
         user.setUserIngredients = nameofingredient.value.split('|');
         await user.findReceipe();
     	const receipes = user.getReceipes();
 	
-	const output = {};
-	const parameterItems = ["first_output_menu","second_output_menu","third_output_menu"];
+		const output = {};
+		const parameterItems = ["first_output_menu","second_output_menu","third_output_menu"];
 	
-	for(let i = 0; i < receipes.length; i++) {
-	   output[parameterItems[i]] = receipes[i];
-	}
-	userList.push(user);;
-	return output;
+		for(let i = 0; i < receipes.length; i++) {
+	   		output[parameterItems[i]] = receipes[i];
+		}
+		userList.push(user);;
+		return output;
 	
     },
     
     getMoreReceipes : async(parameters,session) => {
     
 		const {id} = session;
-		const filteredUser = userList.filter(user => {
+		const [filteredUser] = userList.filter(user => {
 			if(user.getId == id) {
 			   return user;
 			}
 		})
+
 		const receipes = filteredUser.getReceipes()
 		if (receipes === null){
 			//예외상황시 return output 정의해야함
 		}
-		console.log(filteredUser);
+	
 		const output = {};
 		const parameterItems = ["fourth_output_menu","fifth_output_menu","sixth_output_menu"];
 
 		for(let i = 0; i < receipes.length; i++) {
 		   output[parameterItems[i]] = receipes[i];
 		}
-		delete userList(filteredUser)
-		return output;
+		
+		const removeUserIndex = userList.findIndex(user => {
+			if(user.getId == id) {
+				return user;
+			}
+		})
+		userList.splice(removeUserIndex,1);
 
+		return output;
 	
 	}
 }


### PR DESCRIPTION
# 서버단에서 NUGU Play와 테스트 했을때 발생한 에러 반영한 코드 입니다.

### 1. User클래스의 getReceipes() 메서드

  기존코드에서 예외처리를 위해서 `if(this.receipes && this.receipes.length)` 부분을 통과하지 못하고 항상 null이 리턴되는 문제가 있었습니다.  **레시피가 존재하지 않을경우에 먼저 null을 return 시키도록 해서 else 구문 제거**하였습니다.


### 2. nuguService의 getMoreReceipes()

아래코드에서 userList를 필터링 하고 return을 하면 배열 형태로 반환하기 때문에 array destructuring을 통해 배열의 첫 번째 요소를 filteredUser가 참조하도록 하였습니다. ( 제가 코드짤때 실수)
`
const filteredUser = userList.filter(user => {
		if(user.getId == id) {
			   return user;
		}
	})
`



### 3. nuguService의 getMoreReceipes()에서 user를 삭제하는 코드

`delete 연산자`는 객체의 속성을 제거합니다. userList가 배열이기 때문에 delete연산자로 사용자를 삭제할 수 없습니다. 따라서, userList에서 해당 id를 가진 User의 index를 찾아와서 삭제하도록 수정 하였습니다.



<br/>
<br/>
<br/>



# 예외 처리

![image.png](https://images.velog.io/post-images/pa324/22eca5f0-449d-11ea-80e7-5794cdd2448a/image.png)

```
if (receipes === null){
	//예외상황시 return output 정의해야함
}
```

```
if (receipes === null){
	//예외상황시 return output 정의해야함
        nugu.setResultCode("EMPTY-RECEIPE");
        nugu.responseException();
}

```

<br/>
<br/>
<br/>


# 리팩토링 방안

### 1. userList 자료구조 변경
 `userList`를 list로 사용해서 사용자를 저장하고 있는데, 사용자 삭제시 사용자의 인덱스를 찾고 다시 삭제하는 구조 입니다. user인스턴스를 저장하기 위해 userList를 다른 자료구조를 사용하면 좋을듯 합니다. `Queue`를 사용하면 좋지 않을까 생각합니다.  


### 2. 중복 제거
   `user.getReceipes()`를 호출한 후, output 맵핑 작업을 수행하는데 이를 `getReceipes()`에서 진행하면 중복이 제거될것 같습니다.


### 3. 객체 책임 할당

  `Quick and Dirty`로 코드를 구현하였기 때문에, 모든 책임을 `User 클래스`가 가지고 있습니다. 이를 좀 더 효율적인 구조로 개선을 해도 좋을것 같습니다.